### PR TITLE
Use color for live zone extents that is actually visible

### DIFF
--- a/examples/tools/gamepad_viewer.rs
+++ b/examples/tools/gamepad_viewer.rs
@@ -23,9 +23,9 @@ const STICKS_Y: f32 = -135.;
 
 const NORMAL_BUTTON_COLOR: Color = Color::rgb(0.2, 0.2, 0.2);
 const ACTIVE_BUTTON_COLOR: Color = Color::PURPLE;
-const LIVE_COLOR: Color = Color::rgb(0.4, 0.4, 0.4);
+const LIVE_COLOR: Color = Color::rgb(0.5, 0.5, 0.5);
 const DEAD_COLOR: Color = Color::rgb(0.3, 0.3, 0.3);
-const EXTENT_COLOR: Color = Color::rgb(0.2, 0.2, 0.2);
+const EXTENT_COLOR: Color = Color::rgb(0.3, 0.3, 0.3);
 const TEXT_COLOR: Color = Color::WHITE;
 
 #[derive(Component, Deref)]
@@ -289,7 +289,7 @@ fn setup_sticks(
                 // full extent
                 parent.spawn(SpriteBundle {
                     sprite: Sprite {
-                        custom_size: Some(Vec2::splat(STICK_BOUNDS_SIZE * 2.1)),
+                        custom_size: Some(Vec2::splat(STICK_BOUNDS_SIZE * 2.)),
                         color: EXTENT_COLOR,
                         ..default()
                     },


### PR DESCRIPTION
# Objective

Just trying to help with PRs I've commented on.

Implements suggestion from https://github.com/bevyengine/bevy/pull/10102#issuecomment-1760554820

### This PR with the new default `AxisSettings`, with livezone same as extents.

<img width="1280" alt="image" src="https://github.com/mockersf/bevy/assets/200550/cb1f6d26-6035-4fcd-a0d3-be8def35e63a">

### This PR with bevy's old default `AxisSettings`, showing the gap between livezone and extents.

<img width="1280" alt="image" src="https://github.com/mockersf/bevy/assets/200550/65c95e85-2097-4a4e-93d0-8437ff331cac">

